### PR TITLE
Fix Container Flashing in Android N

### DIFF
--- a/app/src/main/java/com/droidsonroids/materialshowcase/utils/GUIUtils.java
+++ b/app/src/main/java/com/droidsonroids/materialshowcase/utils/GUIUtils.java
@@ -33,8 +33,8 @@ public class GUIUtils {
 			@Override
 			public void onAnimationEnd(Animator animation) {
 				super.onAnimationEnd(animation);
-				listener.onRevealHide();
 				view.setVisibility(View.INVISIBLE);
+				listener.onRevealHide();
 			}
 		});
 		anim.setDuration(ctx.getResources().getInteger(R.integer.animation_duration));


### PR DESCRIPTION
in android N the container appeared back for a split second after the revealHide animation had ended.
